### PR TITLE
Enable breakpoints for Fortran - Modern

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
 				"label": "Fortran (GDB)",
 				"enableBreakpointsFor": {
 					"languageIds": [
-						"fortran"
+						"fortran", "fortran-modern"
 					]
 				}
 			}


### PR DESCRIPTION
E.g. `.f90` files.